### PR TITLE
fix: handle window.testFlow being undefined

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -10,7 +10,7 @@ Cypress.on('test:before:run', () => {
 
 Cypress.on('fail', (err) => {
   console.log(err)
-  if (window.testFlow.length) {
+  if (window.testFlow && window.testFlow.length) {
     err.message += `${'\n\n' + 'Test steps were:\n\n'}${window.testFlow.join('\n')}`;
   }
   throw err;


### PR DESCRIPTION
Hi there,

We've noticed this error being thrown from this plugin when there is an issue in the `before` hook in a test:
![CleanShot 2023-04-26 at 10 41 11](https://user-images.githubusercontent.com/6425649/234536872-65a5c705-f38e-451c-a013-b24ba34bb8b2.png)

I'm adding a simple existence check on `window.testFlow` to hopefully fix the problem.