### PR TITLE
fix: place original err.message after steps to work better in CLI

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,17 +1,17 @@
 import { addStyles } from "./addStyles";
 
-Cypress.on('test:before:run', () => {
-
-  addStyles()
+Cypress.on("test:before:run", () => {
+  addStyles();
   window.logCalls = 1;
   window.testFlow = [];
+});
 
-})
-
-Cypress.on('fail', (err) => {
-  console.log(err)
+Cypress.on("fail", (err) => {
+  console.log(err);
   if (window.testFlow.length) {
-    err.message += `${'\n\n' + 'Test steps were:\n\n'}${window.testFlow.join('\n')}`;
+    err.message = `\n\n${"Test steps were:\n\n"}${window.testFlow.join(
+      "\n"
+    )}\n\n${err.message}`;
   }
   throw err;
 });


### PR DESCRIPTION
I have noticed that in the CLI the steps are not always shown, as is also noted in:  #18 

Apprently when you have something like cy.get(..).should(...) and that fails, then the error handling also goes through chai/mocha and everything that comes after the original message will not show in the CLI. Therefore you only see the regular error without the steps that this plugin adds.

When putting the steps first and then the original message, then you do see the steps, both in the CLI as in the GUI, only the order of steps and the actual error message is switched around.
![image](https://github.com/user-attachments/assets/1a8091b2-3718-4bc4-a64c-2b9ad826ff83)

